### PR TITLE
PIZ1: Service and tests to get all sizes 

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if size else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.test.utils.functions import get_random_string, get_random_price
+
+
+def test_create_size_service(create_size):
+    size = create_size.json
+    pytest.assume(create_size.status.startswith('200'))
+    pytest.assume(size['_id'])
+    pytest.assume(size['name'])
+    pytest.assume(size['price'])
+
+
+def test_update_size_service(client, create_size, size_uri):
+    current_size = create_size.json
+    update_data = {**current_size,
+                   'name': get_random_string(), 'price': get_random_price(1, 5)}
+    response = client.put(size_uri, json=update_data)
+    pytest.assume(response.status.startswith('200'))
+    updated_size = response.json
+    for param, value in update_data.items():
+        pytest.assume(updated_size[param] == value)
+
+
+def test_get_size_by_id_service(client, create_size, size_uri):
+    current_size = create_size.json
+    response = client.get(f'{size_uri}id/{current_size["_id"]}')
+    pytest.assume(response.status.startswith('200'))
+    returned_size = response.json
+    for param, value in current_size.items():
+        pytest.assume(returned_size[param] == value)
+
+
+def test_get_size_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {
+        size['_id']: size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
Trello task: [PIZ1 - I can't create an order (Bug)](https://trello.com/c/8BTKDvGS)

Summary:
- The functionality to get all the sizes was implemented but never was used as a service.
- I made the test to prove if the functionality works well using TDD and add the route to complete the task.
- The frontend was waiting for the functionality so, I only need to made changes in the backend.

Changes:
- app/services/size.py: add the route for get all the sizes.
- app/test/services/test_size.py: add the tests for every service about sizes (create, update, get_by_id and get_all).

Captures:
![image](https://user-images.githubusercontent.com/44406603/187472087-1240d52c-a7fa-4864-bf5f-7fe1a2e68a70.png)
