### PR TITLE
PIZ9: Change the order's date format

### DIFF
--- a/app/repositories/models.py
+++ b/app/repositories/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 
 from app.plugins import db
 
@@ -9,7 +9,8 @@ class Order(db.Model):
     client_dni = db.Column(db.String(10))
     client_address = db.Column(db.String(128))
     client_phone = db.Column(db.String(15))
-    date = db.Column(db.DateTime, default=datetime.utcnow)
+    date = db.Column(db.String(20), default=str(
+        date.today().strftime("%d/%m/%Y")))
     total_price = db.Column(db.Float)
     size_id = db.Column(db.Integer, db.ForeignKey('size._id'))
 


### PR DESCRIPTION
Trello task: [PIZ9 - Change the order's date format](https://trello.com/c/48Xvz31E)

Summary:

- The way that the application shows the date to the users was changed to a better format view.
- This help us to improve in UI/UX but also this will help us in the reports task (PIZ5), to split the date and use it easily.

Changes:

- app/repositories/models.py: to refactor the way that we save the date in the model of the order.

Captures:

![image](https://user-images.githubusercontent.com/44406603/187608486-70dc20d7-cf99-4380-93f4-9f406d4cffb9.png)
