### PR TITLE
PIZ13: Create an initial update service for orders

### DIFF
--- a/app/repositories/managers/order.py
+++ b/app/repositories/managers/order.py
@@ -21,7 +21,3 @@ class OrderManager(BaseManager):
                              for beverage in beverages))
         cls.session.commit()
         return cls.serializer().dump(new_order)
-
-    @classmethod
-    def update(cls):
-        raise NotImplementedError(f'Method not suported for {cls.__name__}')

--- a/app/services/order.py
+++ b/app/services/order.py
@@ -1,4 +1,4 @@
-from app.common.http_methods import GET, POST
+from app.common.http_methods import GET, POST, PUT
 from flask import Blueprint, request
 
 from ..controllers import OrderController
@@ -10,6 +10,11 @@ order = Blueprint('order', __name__)
 @order.route('/', methods=POST)
 def create_order():
     return run_service(OrderController, method=POST, request=request.json)
+
+
+@order.route('/', methods=PUT)
+def update_size():
+    return run_service(OrderController, method=PUT, request=request.json)
 
 
 @order.route('/id/<_id>', methods=GET)

--- a/app/test/controllers/test_order.py
+++ b/app/test/controllers/test_order.py
@@ -68,6 +68,25 @@ def test_calculate_order_price(app, ingredients, beverages, size, client_data):
         created_size['price'] + sum(ingredient['price'] for ingredient in created_ingredients) + sum(beverage['price'] for beverage in created_beverages), 2))
 
 
+def test_update_order(app, ingredients, beverages, size, client_data):
+    created_size, created_ingredients, created_beverages = __create_sizes_beverages_and_ingredients(ingredients, beverages, [
+        size])
+    order = __order(created_ingredients, created_beverages,
+                    created_size, client_data)
+    created_order, _ = OrderController.create(order)
+    updated_fields = {
+        '_id': created_order['_id'],
+        'client_name': 'updated',
+        'client_dni': 'updated',
+        'client_address': 'updated',
+        'client_phone': 'updated',
+    }
+    updated_order, error = OrderController.update(updated_fields)
+    pytest.assume(error is None)
+    for param, value in updated_fields.items():
+        pytest.assume(updated_order[param] == value)
+
+
 def test_get_by_id(app, ingredients, beverages, size, client_data):
     created_size, created_ingredients, created_beverages = __create_sizes_beverages_and_ingredients(ingredients, beverages, [
         size])
@@ -104,8 +123,7 @@ def test_get_all(app, ingredients, beverages, sizes, client_data):
         created_orders.append(created_order)
 
     orders_from_db, error = OrderController.get_all()
-    searchable_orders = {db_order['_id']
-        : db_order for db_order in orders_from_db}
+    searchable_orders = {db_order['_id']: db_order for db_order in orders_from_db}
     pytest.assume(error is None)
     for created_order in created_orders:
         current_id = created_order['_id']

--- a/app/test/fixtures/order.py
+++ b/app/test/fixtures/order.py
@@ -24,19 +24,6 @@ def client_data():
 
 
 @pytest.fixture
-def order(create_ingredients, create_beverages, create_size, client_data) -> dict:
-    ingredients = [ingredient.get('_id') for ingredient in create_ingredients]
-    beverages = [beverage.get('_id') for beverage in create_beverages]
-    size_id = create_size.get('_id')
-    return {
-        **client_data_mock(),
-        'ingredients': ingredients,
-        'beverages': beverages,
-        'size_id': size_id
-    }
-
-
-@pytest.fixture
 def create_order(client, order_uri, create_ingredients, create_beverages, create_sizes) -> list:
     ingredients = [ingredient.get('_id') for ingredient in create_ingredients]
     beverages = [beverage.get('_id') for beverage in create_beverages]

--- a/app/test/services/test_order.py
+++ b/app/test/services/test_order.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.test.utils.functions import get_random_string, get_random_price
+from app.test.utils.functions import get_random_string, get_random_phone
 
 
 def test_create_order_service(create_order):
@@ -11,6 +11,22 @@ def test_create_order_service(create_order):
     pytest.assume(order['client_dni'])
     pytest.assume(order['client_name'])
     pytest.assume(order['client_phone'])
+
+
+def test_update_order_service(client, create_order, order_uri):
+    current_order = create_order.json
+    update_data = {
+        '_id': current_order['_id'],
+        'client_name': get_random_string(),
+        'client_dni': get_random_string(),
+        'client_address': get_random_string(),
+        'client_phone': get_random_phone(),
+    }
+    response = client.put(order_uri, json=update_data)
+    pytest.assume(response.status.startswith('200'))
+    updated_order = response.json
+    for param, value in update_data.items():
+        pytest.assume(updated_order[param] == value)
 
 
 def test_get_order_by_id_service(client, create_order, order_uri):

--- a/app/test/utils/functions.py
+++ b/app/test/utils/functions.py
@@ -23,10 +23,6 @@ def shuffle_list(choices: list) -> list:
     return choice_copy
 
 
-def get_random_email() -> str:
-    return f"{get_random_string()}@{get_random_choice(['hotmail.com', 'gmail.com', 'test.com'])}"
-
-
 def get_random_sequence(length: int = 10) -> str:
     digits = list(map(str, range(10)))
     sequence = [digits[random.randint(0, 9)] for _ in range(length)]


### PR DESCRIPTION
Trello task: [PIZ13 - Create an initial update service for the order](https://trello.com/c/bJ83moQb)

Summary:

- To add this initial service I only needed to add the service route with a PUT method and use the default update function in the BaseManager class.

Changes

- app/repositories/managers/order.py: to delete the not implemented update function.
- app/services/order.py: to add the update order service route.
- app/test/controllers/test_order.py: to add the order controllers test.
- app/test/services/test_order.py: to add the order services test.

Captures:

![image](https://user-images.githubusercontent.com/44406603/188297439-a3234fe4-856c-4466-959d-f2aa5b5e0934.png)
![image](https://user-images.githubusercontent.com/44406603/188297465-52646a17-68fb-4c6c-9a30-83c9f9c5750b.png)
